### PR TITLE
feat: add auto label support

### DIFF
--- a/__tests__/functions.test.ts
+++ b/__tests__/functions.test.ts
@@ -89,6 +89,53 @@ describe('Testing compareLabels function', () => {
 })
 
 describe('Testing getIssueLabels function', () => {
+  const autoLabelTestCases = [
+    [
+      `Bahia
+        <!-- AUTO-LABEL:START -->
+        Minas Gerais
+        <!-- AUTO-LABEL:END -->
+        Santa Catarina
+      `,
+      ['Minas Gerais']
+    ],
+    [
+      `<!-- AUTO-LABEL:START -->
+        Bahia
+        <!-- AUTO-LABEL:END -->
+        Minas Gerais
+        <!-- AUTO-LABEL:START -->
+        Santa Catarina
+        <!-- AUTO-LABEL:END -->
+      `,
+      ['Bahia', 'Santa Catarina']
+    ],
+    [
+      `<!-- AUTO-LABEL:END -->
+        <!-- AUTO-LABEL:START -->
+        Bahia
+        <!-- AUTO-LABEL:END -->
+        Minas Gerais
+        <!-- AUTO-LABEL:START -->
+        Santa Catarina
+        <!-- AUTO-LABEL:END -->
+      `,
+      ['Bahia', 'Santa Catarina']
+    ],
+    [
+      `<!-- AUTO-LABEL:START -->
+        Bahia
+        <!-- AUTO-LABEL:END -->
+        Minas Gerais
+        <!-- AUTO-LABEL:START -->
+        Santa Catarina
+        <!-- AUTO-LABEL:END -->
+        <!-- AUTO-LABEL:START -->
+      `,
+      ['Bahia', 'Santa Catarina']
+    ]
+  ]
+
   it('should `new` label', async () => {
     process.env['INPUT_IGNORE-COMMENTS'] = 'false'
     const body = `Testing new feature
@@ -121,6 +168,14 @@ describe('Testing getIssueLabels function', () => {
     const labels = ['bug', 'test', 'new']
     expect(getIssueLabels(body, labels)).toStrictEqual(['bug'])
   })
+
+  test.each(autoLabelTestCases)(
+    'it should return the expected auto labels',
+    (body, expectedAutoLabels) => {
+      const labels = ['Bahia', 'Santa Catarina', 'Minas Gerais']
+      expect(getIssueLabels(body, labels)).toEqual(expectedAutoLabels)
+    }
+  )
 })
 
 describe('Testing getLabelsNotAllowed function', () => {

--- a/__tests__/functions.test.ts
+++ b/__tests__/functions.test.ts
@@ -89,7 +89,40 @@ describe('Testing compareLabels function', () => {
 })
 
 describe('Testing getIssueLabels function', () => {
-  const autoLabelTestCases = [
+  it('should `new` label', async () => {
+    process.env['INPUT_IGNORE-COMMENTS'] = 'false'
+    const body = `Testing new feature
+    not buggy
+    at all... <!-- attention -->`
+    const labels = ['bug', 'test', 'new']
+    expect(getIssueLabels(body, labels)).toStrictEqual(['new'])
+  })
+
+  it('should not add `new` label', async () => {
+    const labels = ['bug', 'test', 'new']
+    const body = `There is an error on system a \r\n\r\n\r\n **VAGA PROGRAMADOR ANGULAR/.NET –n\r\n\r\n <!-- new -->`
+    const body2 = `There is an error on system a \r\n\r\n\r\n **VAGA PROGRAMADOR ANGULAR/.NET –n\r\n\r\n <!--\n\n restes\n new \n-->`
+    const body3 = `There is an bug on system a \r\n\r\n\r\n **VAGA PROGRAMADOR ANGULAR/.NET –n\r\n\r\n <!--\n\n restes\n new \n-->`
+    expect(getIssueLabels(body, labels)).toStrictEqual([])
+    expect(getIssueLabels(body2, labels)).toStrictEqual([])
+    expect(getIssueLabels(body3, labels)).toStrictEqual(['bug'])
+  })
+
+  it('should return default label', async () => {
+    process.env['INPUT_DEFAULT-LABELS'] = `["triage"]`
+    const body = `There is an error on system a \r\n\r\n\r\n **VAGA PROGRAMADOR ANGULAR/.NET –n\r\n\r\n <!-- new -->`
+    const labels = ['bug', 'test', 'new', 'triage']
+    expect(getIssueLabels(body, labels)).toStrictEqual(['triage'])
+  })
+
+  it('should return bug as text `error` is a synonym', async () => {
+    process.env['INPUT_LABELS-SYNONYMS'] = `{"bug":["error"]}`
+    const body = `There is an error on system a \r\n\r\n\r\n **VAGA PROGRAMADOR ANGULAR/.NET –n\r\n\r\n <!-- new -->`
+    const labels = ['bug', 'test', 'new']
+    expect(getIssueLabels(body, labels)).toStrictEqual(['bug'])
+  })
+
+  test.each([
     [
       `Bahia
         <!-- AUTO-LABEL:START -->
@@ -134,42 +167,7 @@ describe('Testing getIssueLabels function', () => {
       `,
       ['Bahia', 'Santa Catarina']
     ]
-  ]
-
-  it('should `new` label', async () => {
-    process.env['INPUT_IGNORE-COMMENTS'] = 'false'
-    const body = `Testing new feature
-    not buggy
-    at all... <!-- attention -->`
-    const labels = ['bug', 'test', 'new']
-    expect(getIssueLabels(body, labels)).toStrictEqual(['new'])
-  })
-
-  it('should not add `new` label', async () => {
-    const labels = ['bug', 'test', 'new']
-    const body = `There is an error on system a \r\n\r\n\r\n **VAGA PROGRAMADOR ANGULAR/.NET –n\r\n\r\n <!-- new -->`
-    const body2 = `There is an error on system a \r\n\r\n\r\n **VAGA PROGRAMADOR ANGULAR/.NET –n\r\n\r\n <!--\n\n restes\n new \n-->`
-    const body3 = `There is an bug on system a \r\n\r\n\r\n **VAGA PROGRAMADOR ANGULAR/.NET –n\r\n\r\n <!--\n\n restes\n new \n-->`
-    expect(getIssueLabels(body, labels)).toStrictEqual([])
-    expect(getIssueLabels(body2, labels)).toStrictEqual([])
-    expect(getIssueLabels(body3, labels)).toStrictEqual(['bug'])
-  })
-
-  it('should return default label', async () => {
-    process.env['INPUT_DEFAULT-LABELS'] = `["triage"]`
-    const body = `There is an error on system a \r\n\r\n\r\n **VAGA PROGRAMADOR ANGULAR/.NET –n\r\n\r\n <!-- new -->`
-    const labels = ['bug', 'test', 'new', 'triage']
-    expect(getIssueLabels(body, labels)).toStrictEqual(['triage'])
-  })
-
-  it('should return bug as text `error` is a synonym', async () => {
-    process.env['INPUT_LABELS-SYNONYMS'] = `{"bug":["error"]}`
-    const body = `There is an error on system a \r\n\r\n\r\n **VAGA PROGRAMADOR ANGULAR/.NET –n\r\n\r\n <!-- new -->`
-    const labels = ['bug', 'test', 'new']
-    expect(getIssueLabels(body, labels)).toStrictEqual(['bug'])
-  })
-
-  test.each(autoLabelTestCases)(
+  ])(
     'it should return the expected auto labels',
     (body, expectedAutoLabels) => {
       const labels = ['Bahia', 'Santa Catarina', 'Minas Gerais']

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "path": "^0.12.7"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.13",
+    "@types/jest": "^26.0.14",
     "@types/node": "^12.0.4",
     "husky": "^4.2.3",
     "jest": "^24.8.0",

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -28,7 +28,6 @@ const compareLabels: Function = (labels: string[]): Function => {
         synonymsObject[synonym.toLowerCase()] = label
       })
     }
-    console.log(synonymsObject)
     const hasLabels = (line: string): string[] => {
       const selectedLabels = line.match(labelsRegex) || []
       return selectedLabels.map(elem => {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -32,7 +32,6 @@ const compareLabels: Function = (labels: string[]): Function => {
     const hasLabels = (line: string): string[] => {
       const selectedLabels = line.match(labelsRegex) || []
       return selectedLabels.map(elem => {
-        console.log('aqui', elem)
         return (
           synonymsObject[elem.toLowerCase()] ||
           labels.find(label => label.toLowerCase() === elem.toLowerCase()) ||
@@ -59,17 +58,35 @@ const compareLabels: Function = (labels: string[]): Function => {
   }
 }
 
+const parseAutoLabel = (body: string): string => {
+  const autoLabelRegex = new RegExp(
+    /<!-- AUTO-LABEL:START -->(?<label>(\s*\w.+|\n)*?)\s*<!-- AUTO-LABEL:END -->/,
+    'gm'
+  )
+  const autoLabels = body.match(autoLabelRegex)
+
+  if (!autoLabels) return body
+
+  const replaceAutoLabelByLabelValue = autoLabel =>
+    autoLabel.replace(autoLabelRegex, '$1').trim()
+
+  return autoLabels.map(replaceAutoLabelByLabelValue).join(' ')
+}
+
 const getIssueLabels: Function = (body: string, labels: string[]): string[] => {
   let selectedLabels: string[] = []
   let hasLabels: Function = compareLabels(labels)
   const ignoreComments = getIgnoreComments()
+
+  const parsedBody = parseAutoLabel(body)
+
   if (ignoreComments) {
-    const noCommentaryBody = body.replace(/\<!--(.|\n)*?-->/g, '')
+    const noCommentaryBody = parsedBody.replace(/\<!--(.|\n)*?-->/g, '')
     hasLabels(noCommentaryBody).map(elem => {
       selectedLabels.push(elem)
     })
   } else {
-    hasLabels(body).map(elem => {
+    hasLabels(parsedBody).map(elem => {
       selectedLabels.push(elem)
     })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,6 +373,16 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@jest/types@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
+  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+
 "@octokit/auth-token@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.0.tgz#b64178975218b99e4dfe948253f0673cbbb59d9f"
@@ -537,12 +547,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^24.0.13":
-  version "24.9.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
-  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
+"@types/jest@^26.0.14":
+  version "26.0.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.14.tgz#078695f8f65cb55c5a98450d65083b2b73e5a3f3"
+  integrity sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==
   dependencies:
-    jest-diff "^24.3.0"
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
 
 "@types/minimatch@^3.0.3":
   version "3.0.3"
@@ -578,6 +589,13 @@
   version "13.0.8"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.8.tgz#a38c22def2f1c2068f8971acb3ea734eb3c64a99"
   integrity sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.0":
+  version "15.0.8"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.8.tgz#7644904cad7427eb704331ea9bf1ee5499b82e23"
+  integrity sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -634,12 +652,24 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
 
 ansi-styles@^4.1.0:
   version "4.2.1"
@@ -1179,6 +1209,11 @@ diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+
+diff-sequences@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
+  integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -2016,7 +2051,7 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.3.0, jest-diff@^24.9.0:
+jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -2025,6 +2060,16 @@ jest-diff@^24.3.0, jest-diff@^24.9.0:
     diff-sequences "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-diff@^25.2.1:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
+  integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.2.6"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
 
 jest-docblock@^24.3.0:
   version "24.9.0"
@@ -2071,6 +2116,11 @@ jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
   integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
+
+jest-get-type@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
+  integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
 
 jest-haste-map@^24.9.0:
   version "24.9.0"
@@ -3066,6 +3116,16 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+pretty-format@^25.2.1, pretty-format@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
+  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 pretty-quick@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-2.0.1.tgz#417ee605ade98ecc686e72f63b5d28a2c35b43e9"
@@ -3119,7 +3179,7 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
closes #13 

Esse PR adiciona o support a auto labels como sugerido na issue #13.

Ao usar auto labels o sitema de tageamento automatico é ignorado, e somente as labels começando com `<!-- AUTO-LABEL:START -->` e terminando em `<!-- AUTO-LABEL:END -->` são usadas.

A ideia da implementação é, ao chamar a função `getIssueLabels`, primeiro parseamos o `body` verificando se o mesmo contem auto labels, com a nova fn `parseAutoLabel`, retornamos apenas o texto referente as labels desejadas. Caso o `body` não contenha auto labels, a função retorna o valor default de `body`.

Também foi adicionado testes cobrindo os casos de uso citados na issue #13.

**OBS:** a implementação atual, não mostra erro em casos onde temos  `<!-- AUTO-LABEL:START -->` e não temos `<!-- AUTO-LABEL:END -->` ou vice e versa, porém, nesses casos são apenas ignorados pois nunca darão match com a regex usada. Os testes adicionados também estão cobrindo isso.

Qualquer feedback é muito bem vindo! 🚀